### PR TITLE
Use full alpha channel for region brightness

### DIFF
--- a/src/components/MapArea.jsx
+++ b/src/components/MapArea.jsx
@@ -57,7 +57,7 @@ export const MapArea = (props) => {
                 d={d3.geoPath().projection(projection)(d)}
                 className="country"
                 fill={`rgba(0,102,204,${
-                  (1 / 50) * region.percentuale_somministrazione
+                  (1 / 100) * region.percentuale_somministrazione
                 })`}
                 stroke="#FFFFFF"
                 strokeWidth={0.7}


### PR DESCRIPTION
alpha channel was tuned to display region with low data not so bright, now data are more consistent and this trick is no longer needed.